### PR TITLE
Feat/lookup optimisations

### DIFF
--- a/test/test_expansions.py
+++ b/test/test_expansions.py
@@ -314,6 +314,22 @@ class AncestorProperties(unittest.TestCase):
         for leaf in e6.leaves:
             self.assertTrue(leaf.is_alternative)
 
+    def test_is_descendant_of(self):
+        e1 = Sequence("hello")
+        self.assertTrue(e1.children[0].is_descendant_of(e1))
+        self.assertFalse(e1.is_descendant_of(e1))
+        self.assertFalse(e1.is_descendant_of(e1.children[0]))
+
+        r = Rule("n", False, AlternativeSet("one", "two", "three"))
+        e2 = RuleRef(r)
+        self.assertFalse(e2.is_descendant_of(e2))
+
+        # Expansions part of the 'n' rule are descendants of e2
+        def assert_descendant(x):
+            self.assertTrue(x.is_descendant_of(e2))
+
+        map_expansion(r.expansion, assert_descendant)
+
 
 class LiteralRepetitionAncestor(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This improves the match performance when using larger grammars (closes issue #2).

Only the `is_descendant_of` and `mutually_exclusive_of` expansion methods have been optimised with caching.  Most other expansion properties/methods like `is_optional` should scale logarithmically with the height of the expansion tree as they are implemented bottom-up - O(log n).

The `invalidate_calculations` method can be used to invalidate all entries in lookup tables referencing an expansion if a child->parent or parent->child relationship has been changed. This is not done automatically because the changes could occur outside of a `JointTreeContext` and propagating such changes would get messy. It is better to make such changes before matching anything.

The population of the lookup tables prior to matching that I mentioned in #2 is unnecessary because of the way `mutually_exclusive_of` stores other related calculations in each call.