### PR TITLE
Add find_matching_part method to Rule class

### DIFF
--- a/jsgf/rules.py
+++ b/jsgf/rules.py
@@ -162,6 +162,33 @@ class Rule(BaseRef):
 
         return self.expansion.current_match is not None
 
+    def find_matching_part(self, speech):
+        """
+        Searches for a part of speech that matches this rule and returns this part.
+        :type speech: str
+        """
+        if not self._active:
+            return False
+
+        # Strip whitespace at the start of 'speech' and lower it to match regex
+        # properly.
+        speech = speech.lstrip().lower()
+
+        split = speech.split(" ")
+        for i in range(0, len(split)):
+            # Reset match data for this rule and referenced rules.
+            self.expansion.reset_for_new_match()
+
+            # Use a JointTreeContext so that this rule's expansion tree and the
+            # expansion trees of referenced rules are joint during matching.
+            with JointTreeContext(self.expansion):
+                result = self.expansion.matches(" ".join(split[i:]))
+                if speech.endswith(result, speech.find(split[i]) + 1):
+                    return self.expansion.current_match
+        
+        self.expansion.current_match = None
+        return None
+
     @property
     def tags(self):
         """


### PR DESCRIPTION
I added a method to Rule which searches for the first matching part in a string. I wrote this method with the old matching process but it seems that it is still working with the new one. Maybe there's a solution which is faster or more elegant than mine. Then please let me know.