### PR TITLE
Update parser.py

### DIFF
--- a/jsgf/parser.py
+++ b/jsgf/parser.py
@@ -102,7 +102,7 @@ def _post_process(tokens):
     def flatten_chain(lst, inst):
         children = []
         for x in lst:
-            if isinstance(x, inst):
+            if isinstance(x, inst) and not x.tag:
                 children.extend(flatten_chain(x.children, inst))
             else:
                 children.append(x)


### PR DESCRIPTION
Keep tags during flattening of sequence chains

Without fix, tags seem to be lost in some cases:

    $ python3 -c "import jsgf; print(jsgf.parse_expansion_string('this (is){tag1} a (test){tag2}'))"
    Sequence(Literal('this'), Literal('is'), Literal('a'), Literal('test'))

With fix, tags remain:

    $ python3 -c "import jsgf; print(jsgf.parse_expansion_string('this (is){tag1} a (test){tag2}'))"
    Sequence(Literal('this'), RequiredGrouping(Literal('is')) with tag 'tag1', Literal('a'), RequiredGrouping(Literal('test')) with tag 'tag2')
