### PR TITLE
Keep required groupings during post processing

### DIFF
--- a/jsgf/parser.py
+++ b/jsgf/parser.py
@@ -210,6 +210,7 @@ def _post_process(tokens):
         should_remove_redundant = (
             len(e.children) == 1 and not e.tag and
             isinstance(e, (AlternativeSet, Sequence)) and
+            not isinstance(e, RequiredGrouping) and
 
             # Check that the parent (if any) has no weight for e.
             not(e.parent and getattr(e.parent, "weights", False) and


### PR DESCRIPTION
Post-processing will remove "redundant" required groupings, which has unexpected consequences.

Before the fix:
    this is a (test | mistake)
parses incorrectly as ParsedAlternativeSet(Sequence(Literal('this is a'), Literal('test')), Literal('mistake')) where the alternatives are ('this is a test' | 'mistake') rather than ('test' |'mistake')

After the fix:
    this is a (test | mistake)
parses correctly as Sequence(Literal('this is a'), ParsedAlternativeSet(Literal('test'), Literal('mistake')))