### PR TITLE
Generate matching strings from rules.

### DIFF
--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1421,7 +1421,7 @@ class Repeat(SingleChildExpansion):
         
     def generate(self):
         c = int(math.log(random.random() / 2, 0.5))
-        return " ".join([self.child.generate()] * c)
+        return " ".join([self.child.generate() for _ in range(c)])
 
     def __hash__(self):
         return super(Repeat, self).__hash__()
@@ -1530,7 +1530,7 @@ class KleeneStar(Repeat):
         
     def generate(self):
         c = int(math.log(random.random() / 2, 0.5)) - 1
-        return " ".join([self.child.generate()] * c)
+        return " ".join([self.child.generate() for _ in range(c)])
 
     @property
     def is_optional(self):

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1705,6 +1705,19 @@ class AlternativeSet(VariableChildExpansion):
             return "(%s)" % alt_set
         
     def generate(self):
+        if self._weights:
+            self._validate_weights()
+            # use weights if they are set
+            # each alternative gets the probability weight / sum_of_all_weights
+            w_sum = sum(self._weights.values())
+            rand = random.random()
+            print("rand = %s" % rand)
+            help_sum = 0
+            for child, weight in self._weights.items():
+                help_sum += (weight / w_sum)
+                print(help_sum)
+                if rand < help_sum:
+                    return child.generate()
         return random.choice(self.children).generate()
 
     def _make_matcher_element(self):

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -2,6 +2,8 @@
 This module contains classes for compiling and matching JSpeech Grammar Format rule
 expansions.
 """
+import math
+import random
 import re
 from copy import deepcopy
 
@@ -453,6 +455,10 @@ class Expansion(object):
             return self.compiled_tag
         else:
             return ""
+        
+    def generate(self):
+        """Generates a string matching this expansion."""
+        return ""
 
     @property
     def parent(self):
@@ -1111,6 +1117,9 @@ class NamedRuleRef(BaseExpansionRef):
             return self.rule.grammar.get_rule_from_name(self.name)
         else:
             raise GrammarError("cannot get referenced Rule object from Grammar")
+    
+    def generate(self):
+        return self.referenced_rule.generate()
 
     def _make_matcher_element(self):
         # Wrap the parser element for the referenced rule's root expansion so that
@@ -1199,6 +1208,9 @@ class SingleChildExpansion(ExpansionWithChildren):
             return None  # the child has been removed
         else:
             return self.children[0]
+        
+    def generate(self):
+        return self.child.generate()
 
     def __hash__(self):
         return super(SingleChildExpansion, self).__hash__()
@@ -1218,6 +1230,9 @@ class SingleChildExpansion(ExpansionWithChildren):
 class VariableChildExpansion(ExpansionWithChildren):
     def __init__(self, *expansions):
         super(VariableChildExpansion, self).__init__(expansions)
+        
+    def generate(self):
+        return " ".join([c for c in [e.generate() for e in self.children] if c])
 
     def __hash__(self):
         return super(VariableChildExpansion, self).__hash__()
@@ -1299,6 +1314,9 @@ class Literal(Expansion):
 
         # Use lowercase text by convention.
         self._text = value.lower()
+        
+    def generate(self):
+        return self.text
 
     def __copy__(self):
         e = type(self)(self.text)
@@ -1400,6 +1418,10 @@ class Repeat(SingleChildExpansion):
             return "(%s)+%s" % (compiled, self.compiled_tag)
         else:
             return "(%s)+" % compiled
+        
+    def generate(self):
+        c = int(math.log(random.random() / 2, 0.5))
+        return " ".join([self.child.generate()] * c)
 
     def __hash__(self):
         return super(Repeat, self).__hash__()
@@ -1505,6 +1527,10 @@ class KleeneStar(Repeat):
             return "(%s)*%s" % (compiled, self.compiled_tag)
         else:
             return "(%s)*" % compiled
+        
+    def generate(self):
+        c = int(math.log(random.random() / 2, 0.5)) - 1
+        return " ".join([self.child.generate()] * c)
 
     @property
     def is_optional(self):
@@ -1525,6 +1551,9 @@ class OptionalGrouping(SingleChildExpansion):
             return "[%s]%s" % (compiled, self.compiled_tag)
         else:
             return "[%s]" % compiled
+        
+    def generate(self):
+        return random.choice([self.child.generate(), ""])
 
     def _make_matcher_element(self):
         return self._set_matcher_element_attributes(
@@ -1674,6 +1703,9 @@ class AlternativeSet(VariableChildExpansion):
             return "(%s)%s" % (alt_set, self.compiled_tag)
         else:
             return "(%s)" % alt_set
+        
+    def generate(self):
+        return random.choice(self.children).generate()
 
     def _make_matcher_element(self):
         # Return an element that can match the alternatives.

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1711,11 +1711,11 @@ class AlternativeSet(VariableChildExpansion):
             # each alternative gets the probability weight / sum_of_all_weights
             w_sum = sum(self._weights.values())
             rand = random.random()
-            print("rand = %s" % rand)
+            # print("rand = %s" % rand)
             help_sum = 0
             for child, weight in self._weights.items():
                 help_sum += (weight / w_sum)
-                print(help_sum)
+                # print(help_sum)
                 if rand < help_sum:
                     return child.generate()
         return random.choice(self.children).generate()

--- a/jsgf/rules.py
+++ b/jsgf/rules.py
@@ -90,6 +90,14 @@ class Rule(BaseRef):
             return "public %s" % result
         else:
             return result
+        
+    def generate(self):
+        """Generates a string matching this rule."""
+        if not self._active:
+            return ""
+        
+        result = self.expansion.generate()
+        return result
 
     def __str__(self):
         return "%s(name='%s', visible=%s, expansion=%s)" %\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+mock
 pyparsing>=2.2.0
 six

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -60,7 +60,21 @@ class ExpansionGenerators(unittest.TestCase):
             self.assertEqual(e.generate(), "hello hello")
             mocked_random.return_value = .12345
             self.assertEqual(e.generate(), "hello hello hello hello")
+
+        indices = [1, 0, 1, 0, 1]  # for five choices
         
+        def choice(lst):
+            i = indices.pop(0)
+            return lst[i]
+
+        e = Repeat(AlternativeSet("hello", "hi"))
+        with patch("random.random", return_value=0) as mocked_random:
+            with patch("random.choice", choice):
+                mocked_random.return_value = .5
+                self.assertEqual(e.generate(), "hi hello")
+                mocked_random.return_value = .25
+                self.assertEqual(e.generate(), "hi hello hi")
+
     def test_kleene_star(self):
         e = KleeneStar("hello")
         with patch("random.random", return_value=0) as mocked_random:
@@ -70,3 +84,17 @@ class ExpansionGenerators(unittest.TestCase):
             self.assertEqual(e.generate(), "hello hello hello")
             mocked_random.return_value = .786
             self.assertEqual(e.generate(), "")
+
+        indices = [1, 0, 1]  # for three choices
+
+        def choice(lst):
+            i = indices.pop(0)
+            return lst[i]
+
+        e = KleeneStar(AlternativeSet("hello", "hi"))
+        with patch("random.random", return_value=0) as mocked_random:
+            with patch("random.choice", choice):
+                mocked_random.return_value = .5
+                self.assertEqual(e.generate(), "hi")
+                mocked_random.return_value = .25
+                self.assertEqual(e.generate(), "hello hi")

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -1,0 +1,58 @@
+import unittest
+import random
+
+from jsgf import *
+
+
+class RuleGenerators(unittest.TestCase):
+    
+    def test_rule(self):
+        e = Sequence("don't", "crash")
+        r = PublicRule("test", e)
+        self.assertEqual(r.generate(), "don't crash")
+
+
+class ExpansionGenerators(unittest.TestCase):
+    
+    def test_literal(self):
+        e = Literal("hello")
+        self.assertEqual(e.generate(), "hello")
+        
+    def test_sequence(self):
+        e = Sequence("hello", "world")
+        self.assertEqual(e.generate(), "hello world")
+        
+    def test_alt_set(self):
+        random.seed(123)
+        hello, hi = map(Literal, ["hello", "hi"])
+        e = AlternativeSet(hello, hi)
+        self.assertEqual(e.generate(), "hello")
+        self.assertEqual(e.generate(), "hi")
+    
+    def test_rule_ref(self):
+        e1 = Sequence("bob")
+        person = HiddenRule("person", e1)
+        e2 = Sequence("hi", RuleRef(person))
+        self.assertEqual(e2.generate(), "hi bob")
+        
+    def test_optional(self):
+        random.seed(123)
+        e = Sequence("hello", OptionalGrouping("there"))
+        self.assertEqual(e.generate(), "hello there")
+        self.assertEqual(e.generate(), "hello")
+
+    def test_repeat(self):
+        random.seed(123)
+        e = Repeat("hello")
+        self.assertEqual(e.generate(), "hello hello hello hello hello")
+        self.assertEqual(e.generate(), "hello hello hello hello")
+        self.assertEqual(e.generate(), "hello hello")
+        
+    def test_kleene_star(self):
+        random.seed(123)
+        e = KleeneStar("hello")
+        self.assertEqual(e.generate(), "hello hello hello hello")
+        self.assertEqual(e.generate(), "hello hello hello")
+        self.assertEqual(e.generate(), "hello")
+        self.assertEqual(e.generate(), "hello hello hello")
+        self.assertEqual(e.generate(), "")


### PR DESCRIPTION
I added the method `generate()` to `Rule` and `Expansion`. This method generates a string which matches the rule or expansion. 
For `AlternativeSet`s the child is choosen randomly with evenly distributed probabilities. Any idea on how to implement this using weights?
For `KleeneStar` and `Repeat` the probability to add the child one more time is 50% each time. This was selected for no good reason.
The chance for an `OptionalGrouping` to appear in the string is also 50%.