### PR TITLE
Fix serialization

### DIFF
--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -912,6 +912,11 @@ class Expansion(object):
     def __contains__(self, item):
         return item in flat_map_expansion(self)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['_matcher_element'] = None
+        return state
+
     @property
     def is_optional(self):
         """

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -2,13 +2,15 @@
 This module contains classes for compiling and matching JSpeech Grammar Format rule
 expansions.
 """
+
+import functools
 import math
 import random
 import re
 from copy import deepcopy
 
 import pyparsing
-from six import string_types, PY2, integer_types
+from six import string_types, integer_types
 
 from .errors import CompilationError, GrammarError
 from .references import BaseRef, optionally_qualified_name
@@ -239,9 +241,10 @@ class JointTreeContext(object):
         map_expansion(self._root, self.detach_tree, TraversalOrder.PostOrder)
 
 
-class ChildList(list):
+@functools.total_ordering
+class ChildList(object):
     """
-    List subclass for expansion child lists.
+    List wrapper class for expansion child lists.
 
     The ``parent`` attribute of each child will be set appropriately when they
     added or removed from lists.
@@ -260,19 +263,45 @@ class ChildList(list):
                 return x
 
             seq = map(f, seq)
-        super(ChildList, self).__init__(seq)
+
+        # Use an internal list rather than sub-classing to avoid pickling issues.
+        self._list = list(seq)
+
+    def __repr__(self):
+        return repr(self._list)
+
+    def __lt__(self, other):
+        return self._list < other
+
+    def __eq__(self, other):
+        return self._list == other
+
+    def __len__(self):
+        return len(self._list)
+
+    def __not__(self):
+        return not(self._list)
+
+    def __add__(self, other):
+        return self._list + other
+
+    def __iadd__(self, other):
+        self._list += other
 
     def append(self, e):
         e = Expansion.make_expansion(e)
-        super(ChildList, self).append(e)
+        self._list.append(e)
         e.parent = self._expansion
+
+    def __iter__(self):
+        return iter(self._list)
 
     def clear(self):
         """
         Remove all expansions from this list and unset their parent attributes.
         """
         # Clear the list using remove().
-        for c in tuple(self):
+        for c in tuple(self._list):
             self.remove(c)
 
     def orphan_children(self):
@@ -291,26 +320,31 @@ class ChildList(list):
             e.parent = self._expansion
 
         # Call the super method to extend the list.
-        super(ChildList, self).extend(iterable)
+        self._list.extend(iterable)
+
+    def index(self, value, start=0, end=None):
+        if end is None:
+            end = len(self._list)
+        return self._list.index(value, start, end)
 
     def insert(self, index, e):
         # Make e an Expansion, call the super method and set e's parent.
         e = Expansion.make_expansion(e)
-        super(ChildList, self).insert(index, e)
+        self._list.insert(index, e)
         e.parent = self._expansion
 
     def pop(self, index=-1):
         # Pop item at the specified index (default -1), set its parent to None
         # and return it.
-        e = super(ChildList, self).pop(index)
+        e = self._list.pop(index)
         e.parent = None
         return e
 
     def remove(self, value):
         # Set the parent before removing the expansion.
         # 'value' is not necessarily in the list, so we can't use that.
-        self[self.index(value)].parent = None
-        super(ChildList, self).remove(value)
+        self._list[self._list.index(value)].parent = None
+        self._list.remove(value)
 
     def __setslice__(self, i, j, sequence):
         """
@@ -327,19 +361,19 @@ class ChildList(list):
         def orphan(x):
             x.parent = None
 
-        [orphan(c) for c in self[i:j]]
+        [orphan(c) for c in self._list[i:j]]
 
-        # Call the appropriate super method for the Python version.
-        if PY2:
-            super(ChildList, self).__setslice__(i, j, sequence)
-        else:
-            super(ChildList, self).__setitem__(slice(i, j), sequence)
+        # Set the slice.
+        self._list[slice(i, j)] = sequence
 
         # Adopt the new children :-)
         def adopt(x):
             x.parent = self._expansion
 
         [adopt(c) for c in sequence]
+
+    def __getitem__(self, key):
+        return self._list[key]
 
     def __setitem__(self, i, value):
         # Handle setting slices separately for my sanity.
@@ -351,13 +385,13 @@ class ChildList(list):
         value = Expansion.make_expansion(value)
 
         # Orphan the old child :-(
-        self[i].parent = None
+        self._list[i].parent = None
 
-        # Call the super method to set the Expansion.
-        super(ChildList, self).__setitem__(i, value)
+        # Set the Expansion in the internal list.
+        self._list[i] = value
 
         # Adopt the new child :-)
-        self[i].parent = self._expansion
+        self._list[i].parent = self._expansion
 
 
 class Expansion(object):
@@ -439,7 +473,7 @@ class Expansion(object):
 
     @children.setter
     def children(self, value):
-        if not isinstance(value, (tuple, list)):
+        if not isinstance(value, (tuple, list, ChildList)):
             raise TypeError("'children' must be a list or tuple")
 
         # Orphan current children if applicable.

--- a/test/test_expansions.py
+++ b/test/test_expansions.py
@@ -156,7 +156,7 @@ class ChildListCase(unittest.TestCase):
         self.assertIsInstance(e.children, ChildList)
         e.children = ChildList(e, ["a", "b", "c"])
         self.assertIsInstance(e.children, ChildList)
-        self.assertListEqual(e.children, [Literal("a"), Literal("b"), Literal("c")])
+        self.assertSequenceEqual(e.children, [Literal("a"), Literal("b"), Literal("c")])
 
         # Check that replacing a ChildList modifies the old list appropriately.
         old_list = e.children
@@ -176,9 +176,9 @@ class ChildListCase(unittest.TestCase):
     def test_equal(self):
         """Equivalent lists and ChildLists should be equal."""
         e = self.e
-        self.assertListEqual(e.children, [Literal(s) for s in ("a", "b", "c")])
+        self.assertSequenceEqual(e.children, [Literal(s) for s in ("a", "b", "c")])
         e = Literal("a")
-        self.assertListEqual(e.children, [])
+        self.assertSequenceEqual(e.children, [])
 
     def test_unequal(self):
         """Different lists and ChildLists should still be unequal."""
@@ -191,17 +191,17 @@ class ChildListCase(unittest.TestCase):
         e = Sequence("a")
         e.children.append("b")
         expected = Sequence("a", "b")
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
 
         # Test insert()
         e = Sequence("a")
         e.children.insert(1, "b")
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
 
         # Test set item
         e = Sequence("a")
         e.children[0] = "b"
-        self.assertListEqual(e.children, Sequence("b").children)
+        self.assertSequenceEqual(e.children, Sequence("b").children)
 
     def test_append(self):
         """Appended children are added and have their parent attributes set."""
@@ -210,7 +210,7 @@ class ChildListCase(unittest.TestCase):
         e.children.append("d")
         e.children.append(OptionalGrouping("e"))
         expected = Sequence("a", "b", "c", "d", OptionalGrouping("e"))
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
         self.assertEqual(e.children[3].parent, e)
         self.assertEqual(e.children[4].parent, e)
 
@@ -228,7 +228,7 @@ class ChildListCase(unittest.TestCase):
         e = Sequence("a")
         e.children.extend(["b", OptionalGrouping("c")])
         expected = Sequence("a", "b", OptionalGrouping("c"))
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
         self.assertEqual(e.children[1].parent, e)
         self.assertEqual(e.children[2].parent, e)
 
@@ -238,7 +238,7 @@ class ChildListCase(unittest.TestCase):
         e.children.insert(0, "a")
         e.children.insert(4, OptionalGrouping("e"))
         expected = Sequence("a", "a", "b", "c", OptionalGrouping("e"))
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
         self.assertEqual(e.children[0].parent, e)
         self.assertEqual(e.children[4].parent, e)
 
@@ -267,7 +267,7 @@ class ChildListCase(unittest.TestCase):
         a, b, c = e.children
         expected = Sequence("x", "y", "z")
         e.children[0:3] = "x", "y", "z"
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
 
         # Check that the old children no longer have e as their parent.
         self.assertIsNone(a.parent)
@@ -280,7 +280,7 @@ class ChildListCase(unittest.TestCase):
         a = e.children[0]
         expected = Sequence("x", "b", "c")
         e.children[0] = "x"
-        self.assertListEqual(e.children, expected.children)
+        self.assertSequenceEqual(e.children, expected.children)
 
         # Check that the old child no longer has e as its parent.
         self.assertIsNone(a.parent)
@@ -907,13 +907,13 @@ class ExpansionTreeConstructs(unittest.TestCase):
 
         self.assertIs(find_expansion(e, find_a, TraversalOrder.PreOrder),
                       e.children[0])
-        self.assertListEqual(visited, [e, e.children[0]])
+        self.assertSequenceEqual(visited, [e, e.children[0]])
 
         # Reset the visited list and test with a post order traversal
         visited = []
         self.assertIs(find_expansion(e, find_a, TraversalOrder.PostOrder),
                       e.children[0])
-        self.assertListEqual(visited, [e.children[0]])
+        self.assertSequenceEqual(visited, [e.children[0]])
 
         # Test again finding 'b' instead
         visited = []
@@ -924,13 +924,13 @@ class ExpansionTreeConstructs(unittest.TestCase):
 
         self.assertIs(find_expansion(e, find_b, TraversalOrder.PreOrder),
                       e.children[2])
-        self.assertListEqual(visited, [e] + e.children)
+        self.assertSequenceEqual(visited, [e] + list(e.children))
 
         # Reset the visited list and test with a post order traversal
         visited = []
         self.assertIs(find_expansion(e, find_b, TraversalOrder.PostOrder),
                       e.children[2])
-        self.assertListEqual(visited, e.children)
+        self.assertSequenceEqual(visited, e.children)
 
 
 class LeafProperties(unittest.TestCase):
@@ -939,7 +939,7 @@ class LeafProperties(unittest.TestCase):
     """
     def test_leaves_base(self):
         e = Literal("hello")
-        self.assertListEqual(e.leaves, [Literal("hello")])
+        self.assertSequenceEqual(e.leaves, [Literal("hello")])
 
     def test_new_leaf_type(self):
         # Make a new Expansion that has no children.
@@ -948,27 +948,27 @@ class LeafProperties(unittest.TestCase):
                 super(TestLeaf, self).__init__([])
 
         e = TestLeaf()
-        self.assertListEqual(e.leaves, [TestLeaf()])
+        self.assertSequenceEqual(e.leaves, [TestLeaf()])
 
     def test_leaves_multiple(self):
         e = Sequence(Literal("hello"), AlternativeSet("there", "friend"))
-        self.assertListEqual(e.leaves, [Literal("hello"), Literal("there"),
+        self.assertSequenceEqual(e.leaves, [Literal("hello"), Literal("there"),
                                         Literal("friend")],
                              "leaves should be in sequence from left to right.")
 
     def test_leaves_with_rule_ref(self):
         r = PublicRule("test", Literal("hi"))
         e = RuleRef(r)
-        self.assertListEqual(e.leaves, [e, Literal("hi")])
+        self.assertSequenceEqual(e.leaves, [e, Literal("hi")])
 
     def test_leaves_after_base(self):
         e = Literal("a")
-        self.assertListEqual(list(e.leaves_after), [])
+        self.assertSequenceEqual(list(e.leaves_after), [])
 
     def test_leaves_after_multiple(self):
         e = Sequence("a", "b")
-        self.assertListEqual(list(e.children[0].leaves_after), [e.children[1]])
-        self.assertListEqual(list(e.children[1].leaves_after), [])
+        self.assertSequenceEqual(list(e.children[0].leaves_after), [e.children[1]])
+        self.assertSequenceEqual(list(e.children[1].leaves_after), [])
 
     def test_leaves_after_complex(self):
         x = Sequence(
@@ -982,33 +982,33 @@ class LeafProperties(unittest.TestCase):
         e = x.children[1]
         f = x.children[2].child
 
-        self.assertListEqual(list(a.leaves_after), [b, c, d, e, f])
-        self.assertListEqual(list(b.leaves_after), [c, d, e, f])
-        self.assertListEqual(list(c.leaves_after), [d, e, f])
-        self.assertListEqual(list(d.leaves_after), [e, f])
-        self.assertListEqual(list(e.leaves_after), [f])
-        self.assertListEqual(list(f.leaves_after), [])
+        self.assertSequenceEqual(list(a.leaves_after), [b, c, d, e, f])
+        self.assertSequenceEqual(list(b.leaves_after), [c, d, e, f])
+        self.assertSequenceEqual(list(c.leaves_after), [d, e, f])
+        self.assertSequenceEqual(list(d.leaves_after), [e, f])
+        self.assertSequenceEqual(list(e.leaves_after), [f])
+        self.assertSequenceEqual(list(f.leaves_after), [])
 
     def test_collect_leaves(self):
         n = Rule("n", False, AlternativeSet("one", "two", "three"))
         e = Sequence("test", RuleRef(n))
 
         # Test with default parameters
-        self.assertListEqual(
+        self.assertSequenceEqual(
             e.collect_leaves(order=TraversalOrder.PreOrder, shallow=False),
             #    test         RuleRef(n)       one, two, three
-            [e.children[0], e.children[1]] + n.expansion.children
+            [e.children[0], e.children[1]] + list(n.expansion.children)
         )
 
         # Test with PostOrder traversal
-        self.assertListEqual(
+        self.assertSequenceEqual(
             e.collect_leaves(order=TraversalOrder.PostOrder, shallow=False),
             #     test          one, two, three        RuleRef(n)
-            [e.children[0]] + n.expansion.children + [e.children[1]]
+            [e.children[0]] + list(n.expansion.children) + [e.children[1]]
         )
 
         # Test with shallow=True (order is irrelevant in this case)
-        self.assertListEqual(
+        self.assertSequenceEqual(
             e.collect_leaves(shallow=True),
             #     test        RuleRef(n)
             [e.children[0], e.children[1]]


### PR DESCRIPTION
Fixes #26.

@rhyspang This should allow grammars, rules and elements/expansions to be serialized properly with `dill`. Pyparsing matcher elements are not preserved in the pickling process because they don't seem to support pickling.

You probably don't need this any more, sorry it took me so long to fix it!