### PR TITLE
Add 'case_sensitive' properties to Literal, Rule & Grammar classes

### DIFF
--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1331,6 +1331,7 @@ class Literal(Expansion):
         # Set _text and use the text setter to validate the input.
         self._text = ""
         self.text = text
+        self._case_sensitive = None
         super(Literal, self).__init__([])
 
     def __str__(self):
@@ -1340,23 +1341,48 @@ class Literal(Expansion):
         return hash("%s" % self)
 
     @property
+    def case_sensitive(self):
+        """
+        Case sensitivity used when matching and compiling :class:`Literal` rule
+        expansions.
+
+        This property can be ``True`` or ``False``. Matching and compilation will
+        be *case-sensitive* if ``True`` and *case-insensitive* if ``False``. The
+        default value is ``False``.
+
+        :rtype: bool
+        :returns: literal case sensitivity
+        """
+        return self._case_sensitive
+
+    @case_sensitive.setter
+    def case_sensitive(self, value):
+        self._case_sensitive = bool(value)
+        self.invalidate_matcher()
+
+    @property
     def text(self):
         """
         Text to match/compile.
 
-        Text will be put in lowercase. Override ``text``'s setter to
-        change that behaviour.
+        This will return lowercase text if :py:attr:`~case_sensitive` is not
+        ``True``.
+
+        :rtype: str
+        :returns: text
         """
-        return self._text
+        text = self._text
+        if not self.case_sensitive:
+            text = text.lower()
+        return text
 
     @text.setter
     def text(self, value):
         if not isinstance(value, string_types):
             raise TypeError("expected string, got %s instead" % value)
 
-        # Use lowercase text by convention.
-        self._text = value.lower()
-        
+        self._text = value
+
     def generate(self):
         """
         Generate a string matching this expansion's text.
@@ -1410,7 +1436,13 @@ class Literal(Expansion):
         return re.compile(r"\s+".join(words))
 
     def _make_matcher_element(self):
-        return self._set_matcher_element_attributes(pyparsing.Literal(self.text))
+        # Return a case-sensitive or case-insensitive pyparsing Literal element.
+        text = self._text
+        if self.case_sensitive:
+            matcher_cls = pyparsing.Literal
+        else:
+            matcher_cls = pyparsing.CaselessLiteral
+        return self._set_matcher_element_attributes(matcher_cls(text))
 
     def __eq__(self, other):
         return super(Literal, self).__eq__(other) and self.text == other.text

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1445,7 +1445,8 @@ class Literal(Expansion):
         return self._set_matcher_element_attributes(matcher_cls(text))
 
     def __eq__(self, other):
-        return super(Literal, self).__eq__(other) and self.text == other.text
+        return (super(Literal, self).__eq__(other) and self.text == other.text and
+                self.case_sensitive == other.case_sensitive)
 
 
 class RuleRef(NamedRuleRef):

--- a/jsgf/expansions.py
+++ b/jsgf/expansions.py
@@ -1327,11 +1327,11 @@ class Literal(Expansion):
     """
     Expansion class for literals.
     """
-    def __init__(self, text):
+    def __init__(self, text, case_sensitive=False):
         # Set _text and use the text setter to validate the input.
         self._text = ""
         self.text = text
-        self._case_sensitive = None
+        self._case_sensitive = bool(case_sensitive)
         super(Literal, self).__init__([])
 
     def __str__(self):

--- a/jsgf/ext/grammars.py
+++ b/jsgf/ext/grammars.py
@@ -15,12 +15,13 @@ class DictationGrammar(Grammar):
     Grammar subclass that processes rules using ``Dictation`` expansions so they can
     be compiled, matched and used with normal JSGF rules with utterance breaks.
     """
-    def __init__(self, rules=None, name="default"):
+    def __init__(self, rules=None, name="default", case_sensitive=False):
         """
         :param rules: list
         :param name: str
+        :param case_sensitive: bool
         """
-        super(DictationGrammar, self).__init__(name)
+        super(DictationGrammar, self).__init__(name, case_sensitive=case_sensitive)
         self._dictation_rules = []
         self._original_rule_map = {}
         self._init_jsgf_only_grammar()
@@ -35,7 +36,8 @@ class DictationGrammar(Grammar):
 
         Override this to use a different grammar class.
         """
-        self._jsgf_only_grammar = Grammar(name=self.name)
+        self._jsgf_only_grammar = Grammar(name=self.name,
+                                          case_sensitive=self.case_sensitive)
 
     @property
     def rules(self):

--- a/jsgf/ext/rules.py
+++ b/jsgf/ext/rules.py
@@ -15,13 +15,8 @@ class SequenceRule(Rule):
     Class representing a list of regular expansions and ``Dictation`` expansions
     that must be spoken in a sequence.
     """
-    def __init__(self, name, visible, expansion):
-        """
-        :param name: str
-        :param visible: bool
-        :param expansion:
-        """
-        super(SequenceRule, self).__init__(name, visible, expansion)
+    def __init__(self, name, visible, expansion, case_sensitive=False):
+        super(SequenceRule, self).__init__(name, visible, expansion, case_sensitive)
 
         # Keep the original expansion and use a copy of it for the sequence
         self._original_expansion = self.expansion
@@ -293,8 +288,9 @@ class PublicSequenceRule(SequenceRule):
     """
     SequenceRule subclass with ``visible`` set to True.
     """
-    def __init__(self, name, expansion):
-        super(PublicSequenceRule, self).__init__(name, True, expansion)
+    def __init__(self, name, expansion, case_sensitive=False):
+        super(PublicSequenceRule, self).__init__(name, True, expansion,
+                                                 case_sensitive)
 
     def __hash__(self):
         return super(PublicSequenceRule, self).__hash__()
@@ -308,8 +304,9 @@ class HiddenSequenceRule(SequenceRule):
     """
     SequenceRule subclass with ``visible`` set to False.
     """
-    def __init__(self, name, expansion):
-        super(HiddenSequenceRule, self).__init__(name, False, expansion)
+    def __init__(self, name, expansion, case_sensitive=False):
+        super(HiddenSequenceRule, self).__init__(name, False, expansion,
+                                                 case_sensitive)
 
     def __hash__(self):
         return super(HiddenSequenceRule, self).__hash__()

--- a/jsgf/grammars.py
+++ b/jsgf/grammars.py
@@ -71,6 +71,7 @@ class Grammar(BaseRef):
         self._imports = []
         self.jsgf_version, self.charset_name, self.language_name =\
             self.default_header_values
+        self._case_sensitive = False
 
     @property
     def jsgf_header(self):
@@ -94,6 +95,29 @@ class Grammar(BaseRef):
     @staticmethod
     def valid(name):
         return grammar_name.matches(name)
+
+    @property
+    def case_sensitive(self):
+        """
+        Case sensitivity used when matching and compiling :class:`Literal` rule
+        expansions whose ``case_sensitive`` values are ``None`` (default).
+
+        Grammars are *case-insensitive* by default.
+
+        Setting this property will override the ``case_sensitive`` value for each
+        :class:`Rule` and :class:`Literal` expansion in the grammar.
+
+        :rtype: bool
+        :returns: case sensitivity
+        """
+        return self._case_sensitive
+
+    @case_sensitive.setter
+    def case_sensitive(self, value):
+        value = bool(value)
+        self._case_sensitive = value
+        for rule in self.rules:
+            rule.case_sensitive = value
 
     def compile(self):
         """

--- a/jsgf/grammars.py
+++ b/jsgf/grammars.py
@@ -289,7 +289,8 @@ class Grammar(BaseRef):
 
     def __eq__(self, other):
         return (self.name == other.name and self.jsgf_header == other.jsgf_header
-                and self.rules == other.rules and self.imports == other.imports)
+                and self.rules == other.rules and self.imports == other.imports
+                and self.case_sensitive == other.case_sensitive)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/jsgf/grammars.py
+++ b/jsgf/grammars.py
@@ -65,13 +65,16 @@ class Grammar(BaseRef):
         ""
     )
 
-    def __init__(self, name="default"):
+    def __init__(self, name="default", case_sensitive=False):
         super(Grammar, self).__init__(name)
         self._rules = []
         self._imports = []
         self.jsgf_version, self.charset_name, self.language_name =\
             self.default_header_values
-        self._case_sensitive = False
+
+        # Set case sensitivity (backing attribute and property).
+        self._case_sensitive = case_sensitive
+        self.case_sensitive = case_sensitive
 
     @property
     def jsgf_header(self):
@@ -100,11 +103,9 @@ class Grammar(BaseRef):
     def case_sensitive(self):
         """
         Case sensitivity used when matching and compiling :class:`Literal` rule
-        expansions whose ``case_sensitive`` values are ``None`` (default).
+        expansions.
 
-        Grammars are *case-insensitive* by default.
-
-        Setting this property will override the ``case_sensitive`` value for each
+        Setting this property will override the ``case_sensitive`` values for each
         :class:`Rule` and :class:`Literal` expansion in the grammar.
 
         :rtype: bool
@@ -475,8 +476,8 @@ class RootGrammar(Grammar):
 
     This is useful if you are using JSGF grammars with CMU Pocket Sphinx.
     """
-    def __init__(self, rules=None, name="root"):
-        super(RootGrammar, self).__init__(name)
+    def __init__(self, rules=None, name="root", case_sensitive=False):
+        super(RootGrammar, self).__init__(name, case_sensitive)
         if rules:
             self.add_rules(*rules)
 

--- a/jsgf/grammars.py
+++ b/jsgf/grammars.py
@@ -71,10 +71,7 @@ class Grammar(BaseRef):
         self._imports = []
         self.jsgf_version, self.charset_name, self.language_name =\
             self.default_header_values
-
-        # Set case sensitivity (backing attribute and property).
         self._case_sensitive = case_sensitive
-        self.case_sensitive = case_sensitive
 
     @property
     def jsgf_header(self):
@@ -106,7 +103,8 @@ class Grammar(BaseRef):
         expansions.
 
         Setting this property will override the ``case_sensitive`` values for each
-        :class:`Rule` and :class:`Literal` expansion in the grammar.
+        :class:`Rule` and :class:`Literal` expansion in the grammar or in any newly
+        added grammar rules.
 
         :rtype: bool
         :returns: case sensitivity
@@ -300,6 +298,9 @@ class Grammar(BaseRef):
         """
         Add multiple rules to the grammar.
 
+        This method will override each new rule's :py:attr:`~Rule.case_sensitive`
+        value with the grammar's :py:attr:`~case_sensitive` value.
+
         :param rules: rules
         :raises: GrammarError
         """
@@ -319,6 +320,9 @@ class Grammar(BaseRef):
         """
         Add a rule to the grammar.
 
+        This method will override the new rule's :py:attr:`~Rule.case_sensitive`
+        value with the grammar's :py:attr:`~case_sensitive` value.
+
         :param rule: Rule
         :raises: GrammarError
         """
@@ -337,6 +341,9 @@ class Grammar(BaseRef):
 
         self._rules.append(rule)
         rule.grammar = self
+
+        # Set case sensitivity.
+        rule.case_sensitive = self.case_sensitive
 
     def add_import(self, _import):
         """

--- a/jsgf/rules.py
+++ b/jsgf/rules.py
@@ -30,11 +30,13 @@ class Rule(BaseRef):
     used as rule names. You can however change the case to 'null' or 'void' to use
     them, as names are case-sensitive.
     """
-    def __init__(self, name, visible, expansion):
+    def __init__(self, name, visible, expansion, case_sensitive=False):
         """
         :param name: str
         :param visible: bool
         :param expansion: a string or Expansion object
+        :param case_sensitive: whether rule literals should be case sensitive
+            (default False).
         """
         super(Rule, self).__init__(name)
         self.visible = visible
@@ -42,7 +44,10 @@ class Rule(BaseRef):
         self.expansion = expansion
         self._active = True
         self.grammar = None
-        self._case_sensitive = None
+
+        # Set case sensitivity (backing attribute and property).
+        self._case_sensitive = case_sensitive
+        self.case_sensitive = case_sensitive
 
     @property
     def expansion(self):
@@ -368,8 +373,8 @@ class PublicRule(Rule):
     """
     Rule subclass with ``visible`` set to True.
     """
-    def __init__(self, name, expansion):
-        super(PublicRule, self).__init__(name, True, expansion)
+    def __init__(self, name, expansion, case_sensitive=False):
+        super(PublicRule, self).__init__(name, True, expansion, case_sensitive)
 
     def __hash__(self):
         return super(PublicRule, self).__hash__()
@@ -383,8 +388,8 @@ class HiddenRule(Rule):
     """
     Rule subclass with ``visible`` set to False.
     """
-    def __init__(self, name, expansion):
-        super(HiddenRule, self).__init__(name, False, expansion)
+    def __init__(self, name, expansion, case_sensitive=False):
+        super(HiddenRule, self).__init__(name, False, expansion, case_sensitive)
 
     def __hash__(self):
         return super(HiddenRule, self).__hash__()

--- a/jsgf/rules.py
+++ b/jsgf/rules.py
@@ -5,8 +5,9 @@ This module contains classes for compiling and matching JSpeech Grammar Format
 rules.
 """
 
+from .errors import GrammarError
 from .references import BaseRef
-from .expansions import Expansion, NamedRuleRef, filter_expansion, \
+from .expansions import Expansion, Literal, NamedRuleRef, filter_expansion, \
     map_expansion, TraversalOrder
 
 
@@ -41,6 +42,7 @@ class Rule(BaseRef):
         self.expansion = expansion
         self._active = True
         self.grammar = None
+        self._case_sensitive = None
 
     @property
     def expansion(self):
@@ -117,6 +119,46 @@ class Rule(BaseRef):
         return hash("%s%s%s" % (hash(self.name),
                                 hash(self.visible), hash(self.expansion)))
 
+    @property
+    def case_sensitive(self):
+        """
+        Case sensitivity used when matching and compiling :class:`Literal` rule
+        expansions.
+
+        This property can be ``True`` or ``False``. Matching and compilation will
+        be *case-sensitive* if ``True`` and *case-insensitive* if ``False``. The
+        default value is ``False``.
+
+        Setting this property will override the ``case_sensitive`` value for each
+        :class:`Literal` in the rule and in referenced rules.
+
+        :rtype: bool
+        :returns: literal case sensitivity
+        """
+        return self._case_sensitive
+
+    @case_sensitive.setter
+    def case_sensitive(self, value):
+        value = bool(value)
+        self._case_sensitive = value
+
+        # Define a function for setting case_sensitive for all Literal rule
+        # expansions.
+        def func(e):
+            if isinstance(e, Literal):
+                e.case_sensitive = value
+            elif isinstance(e, NamedRuleRef):
+                # Set case_sensitive for referenced rules. Ignore references that
+                # don't resolve to actual Rule objects.
+                try:
+                    e.referenced_rule.case_sensitive = value
+                except GrammarError:
+                    pass
+
+        # Recursively operate on the rule expansion tree. Do *not* operate on
+        # referenced rules directly.
+        map_expansion(self.expansion, func, shallow=True)
+
     def enable(self):
         """
         Allow this rule to produce compile output and to match speech strings.
@@ -168,7 +210,7 @@ class Rule(BaseRef):
 
         # Strip whitespace at the start of 'speech' and lower it to match regex
         # properly.
-        speech = speech.lstrip().lower()
+        speech = speech.lstrip()
 
         # Reset match data for this rule and referenced rules.
         self.expansion.reset_for_new_match()

--- a/jsgf/rules.py
+++ b/jsgf/rules.py
@@ -363,7 +363,8 @@ class Rule(BaseRef):
     def __eq__(self, other):
         return (self.name == other.name and
                 self.expansion == other.expansion and
-                self.visible == other.visible)
+                self.visible == other.visible and
+                self.case_sensitive == other.case_sensitive)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/test/test_expansions.py
+++ b/test/test_expansions.py
@@ -292,6 +292,13 @@ class Comparisons(unittest.TestCase):
         self.assertNotEqual(Literal("hey"), Literal("hello"))
         self.assertNotEqual(Literal("hey"), Sequence(Literal("hello")))
 
+        # Check case-sensitive vs case-insensitive literals.
+        self.assertEqual(Literal("HELLO", False), Literal("HELLO", False))
+        self.assertEqual(Literal("HELLO", True), Literal("HELLO", True))
+        self.assertEqual(Literal("hello", False), Literal("HELLO", False))
+        self.assertNotEqual(Literal("hello", False), Literal("HELLO", True))
+        self.assertNotEqual(Literal("HELLO", False), Literal("HELLO", True))
+
     def test_alt_sets(self):
         self.assertEqual(AlternativeSet("hello", "hi"),
                          AlternativeSet("hello", "hi"))

--- a/test/test_expansions.py
+++ b/test/test_expansions.py
@@ -516,11 +516,13 @@ class LiteralProperties(unittest.TestCase):
         e.text = "b"
         self.assertEqual(e.text, "b")
 
-    def test_text_lowercase(self):
-        """Literal.text gets and sets lowercase strings."""
+    def test_text_casing(self):
+        """Literal.text property can return lowered or unchanged strings."""
         e = Literal("A")
         self.assertEqual(e.text, "a")
-        e.text = "A"
+        e.case_sensitive = True
+        self.assertEqual(e.text, "A")
+        e.text = "a"
         self.assertEqual(e.text, "a")
 
     def test_set_text_valid_type(self):

--- a/test/test_ext_rules.py
+++ b/test/test_ext_rules.py
@@ -198,11 +198,11 @@ class SequenceRuleGraftMatchMethods(unittest.TestCase):
         self.assertEqual(l1.current_match, "test with")
         self.assertEqual(alt_set.current_match, "lots of")
         self.assertEqual(d1.current_match, "dictation")
-        self.assertEqual(l2.current_match, "and jsgf")
+        self.assertEqual(l2.current_match, "and JSGF")
         self.assertEqual(l3.current_match, "expansions")
         self.assertEqual(d2.current_match, "hopefully")
         self.assertEqual(d3.current_match, "maybe")
-        self.assertEqual(seq.current_match, "test with lots of dictation and jsgf "
+        self.assertEqual(seq.current_match, "test with lots of dictation and JSGF "
                                             "expansions hopefully maybe")
 
     def test_graft_matches_onto_unrelated(self):

--- a/test/test_grammars.py
+++ b/test/test_grammars.py
@@ -187,6 +187,12 @@ class BasicGrammarCase(unittest.TestCase):
 
         self.assertEqual(RootGrammar(name="test"), Grammar(name="test"),
                          "grammars with only different types should be equal")
+
+        # Check case-sensitive vs case-insensitive grammars.
+        self.assertNotEqual(
+            Grammar(case_sensitive=False), Grammar(case_sensitive=True),
+            "grammars with different case sensitivity should not be equal")
+
     def test_jsgf_header(self):
         """ JSGF header uses grammar header attributes correctly. """
         grammar = Grammar()

--- a/test/test_grammars.py
+++ b/test/test_grammars.py
@@ -248,9 +248,14 @@ class BasicGrammarCase(unittest.TestCase):
         self.assertFalse(grammar.case_sensitive)
         self.assertEqual(grammar.compile(), expected_insensitive)
 
-        # Test case-sensitive compilation and matching.
+        # Test that setting grammar.case_sensitive overrides the values for each
+        # grammar rule.
         grammar.case_sensitive = True
         self.assertTrue(grammar.case_sensitive)
+        for rule in grammar.rules:
+            self.assertTrue(rule.case_sensitive)
+
+        # Test case-sensitive compilation and matching.
         self.assertEqual(grammar.compile(), expected_sensitive)
         self.assertSequenceEqual(grammar.find_matching_rules("Up Two"), [cmd_rule])
         self.assertSequenceEqual(grammar.find_matching_rules("up two"), [])

--- a/test/test_matches.py
+++ b/test/test_matches.py
@@ -216,7 +216,7 @@ class MatchesCase(unittest.TestCase):
 
         # Test the order in which child expansions are matched.
         self.assertEqual(repr(e.matcher_element),
-                         '{"three" ^ "two" ^ "one"}')
+                         '{"three" ^ "two" ^ "one"}'.replace('"', "'"))
 
         # Each alternative should be matchable with non-zero weights.
         r = Rule("test", True, e)
@@ -232,7 +232,7 @@ class MatchesCase(unittest.TestCase):
 
         # Test the order in which child expansions are matched.
         self.assertEqual(repr(e.matcher_element),
-                         '{"three" ^ "two"}')
+                         '{"three" ^ "two"}'.replace('"', "'"))
 
         # Test that no alternatives can match if all weights are 0.
         e.weights = {one: 0, two: 0, three: 0}

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -139,6 +139,56 @@ class MemberTests(unittest.TestCase):
         self.assertIsNone(r1.find_matching_part("hello world"))
         self.assertIsNone(r1.find_matching_part("test"))
 
+    def test_case_sensitive(self):
+        """JSGF Rules support configurable case-sensitivity."""
+        direction = Rule("direction", False, AlternativeSet(
+            "Up", "Down", "Left", "Right"
+        ))
+        cmd = Rule("cmd", True, Sequence("Go", RuleRef(direction)))
+
+        # Add our rules to a grammar so that matcher invalidation works.
+        grammar = Grammar()
+        grammar.add_rules(direction, cmd)
+
+        # Change sensitivity for one rule. Check compilation and matching.
+        direction.case_sensitive = True
+        self.assertTrue(direction.case_sensitive)
+        self.assertEqual(direction.compile(), "<direction> = (Up|Down|Left|Right);")
+        self.assertTrue(direction.matches("Up"))
+        self.assertFalse(direction.matches("up"))
+
+        # Test that the "cmd" rule's matches() method is affected by the "direction"
+        # rule's case-sensitivity.
+        self.assertFalse(cmd.matches("go up"))
+        self.assertTrue(cmd.matches("go Up"))
+
+        # Change sensitivity back and check again to make sure the casing is not
+        # lost.
+        direction.case_sensitive = False
+        self.assertFalse(direction.case_sensitive)
+        self.assertEqual(direction.compile(), "<direction> = (up|down|left|right);")
+        self.assertTrue(direction.matches("Up"))
+        self.assertTrue(direction.matches("up"))
+
+        # Test "cmd" matching again.
+        self.assertTrue(cmd.matches("go up"))
+        self.assertTrue(cmd.matches("go Up"))
+
+        # Change sensitivity for the "cmd" rule.
+        cmd.case_sensitive = True
+        self.assertTrue(cmd.case_sensitive)
+        self.assertEqual(cmd.compile(), "public <cmd> = Go <direction>;")
+
+        # Test that the "direction" rule was affected by the change.
+        self.assertTrue(direction.case_sensitive)
+        self.assertEqual(direction.compile(), "<direction> = (Up|Down|Left|Right);")
+        self.assertTrue(direction.matches("Up"))
+        self.assertFalse(direction.matches("up"))
+
+        # Check compilation and matching.
+        self.assertTrue(cmd.matches("Go Up"))
+        self.assertFalse(cmd.matches("go up"))
+
 
 class InvalidRules(unittest.TestCase):
     def test_invalid_rules(self):

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -257,6 +257,16 @@ class ComparisonTests(unittest.TestCase):
             PublicRule("test", "test"), Rule("test", True, "test"),
             "rules with only different types were not equal")
 
+    def test_case_sensitive(self):
+        # Check case-sensitive vs case-insensitive rules.
+        r1 = Rule("test", True, "hello", True)
+        r2 = Rule("test", True, "hello", True)
+        self.assertEqual(r1, r2)
+        r1.case_sensitive = False
+        self.assertNotEqual(r1, r2)
+        r2.case_sensitive = False
+        self.assertEqual(r1, r2)
+
     def test_hashing(self):
         h = hash
         # Rules that are the same should generate the same hash


### PR DESCRIPTION
All three classes can now be configured to use case sensitivity for grammar words. This effects how compilation and matching work.

This also adds tests and documentation.

### Example with `PublicRule`
```Python
from jsgf import PublicRule

rule = PublicRule("rule", "I live in Germany")

# Case-insensitive (default):
print(rule)
print(rule.compile())
print(rule.matches("i live in germany"))

# Case-sensitive:
rule.case_sensitive = True
print(rule)
print(rule.compile())
print(rule.matches("i live in germany"))
print(rule.matches("I live in Germany"))
```

Setting a `Rule` object's `case_sensitive` property will override the `case_sensitive` properties for each of the rule's direct and referenced `Literal` rule expansions. Likewise, setting a `Grammar` object's `case_sensitive` property will override the values for each `Rule` and `Literal` in the grammar.